### PR TITLE
Fix stale references to upstream drinkataco fork and its domain

### DIFF
--- a/.github/workflows/chart-page.yaml
+++ b/.github/workflows/chart-page.yaml
@@ -3,7 +3,7 @@ name: Chart page
 on:
   push:
     branches:
-      - base
+      - main
 
 # permissions are needed if pushing to ghcr.io
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DIST := dist/charts
 CHARTS ?= $(shell ls -d $(CHARTS_DIR)/*/ | xargs -n 1 basename)
 
 # Location of Repo
-HELM_REPO ?= https://media-servarr.shw.al/charts
+HELM_REPO ?= https://munsio.github.io/media-servarr
 
 # Default target
 build: package pre-fetch index

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # media-servarr helm charts
 
-[![Lint](https://github.com/drinkataco/media-servarr/actions/workflows/lint.yaml/badge.svg)](https://github.com/drinkataco/media-servarr/actions/workflows/lint.yaml)
-[![Release](https://github.com/drinkataco/media-servarr/actions/workflows/release.yaml/badge.svg)](https://github.com/drinkataco/media-servarr/actions/workflows/release.yaml)
-[![App Update](https://github.com/drinkataco/media-servarr/actions/workflows/auto-update.yaml/badge.svg)](https://github.com/drinkataco/media-servarr/actions/workflows/auto-update.yaml)
+[![Lint](https://github.com/Munsio/media-servarr/actions/workflows/lint.yaml/badge.svg)](https://github.com/Munsio/media-servarr/actions/workflows/lint.yaml)
+[![Chart page](https://github.com/Munsio/media-servarr/actions/workflows/chart-page.yaml/badge.svg)](https://github.com/Munsio/media-servarr/actions/workflows/chart-page.yaml)
+[![App Update](https://github.com/Munsio/media-servarr/actions/workflows/auto-update.yaml/badge.svg)](https://github.com/Munsio/media-servarr/actions/workflows/auto-update.yaml)
 
 ![media-servarr](./icon.png)
 
@@ -20,7 +20,7 @@ The aim of this repository is to be featureful, use repeatable code, and to be a
 Add the repository using:
 
 ```bash
-helm repo add media-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 ```
 
 And then view all available charts with

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'bazarr'
 description: 'Companion application to Sonarr and Radarr to manage and download subtitles'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/bazarr'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/bazarr'
 keywords:
   - 'subtitles'
   - 'torrent'
@@ -15,17 +15,17 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 1.5.6
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/bazarr/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/morpheus65535/Bazarr'
   - 'https://github.com/linuxserver/docker-bazarr'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/bazarr'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/bazarr'

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -28,7 +28,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install bazarr media-servarr/bazarr
 ```

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'jellyfin'
 description: 'A free software media system that puts you in control of managing and streaming your media'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/jellyfin'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/jellyfin'
 keywords:
   - 'music'
   - 'tv'
@@ -17,15 +17,15 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 10.11.11
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/jellyfin/jellyfin'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/jellyfin'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/jellyfin'

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -26,7 +26,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install jellyfin media-servarr/jellyfin
 ```

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'prowlarr'
 description: 'BitTorrent indexer management'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/prowlarr'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/prowlarr'
 keywords:
   - 'bittorrent'
   - 'torrent'
@@ -12,17 +12,17 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 2.4.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/Prowlarr/Prowlarr'
   - 'https://github.com/linuxserver/docker-prowlarr'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/prowlarr'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/prowlarr'

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -28,7 +28,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install prowlarr media-servarr/prowlarr
 ```

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'radarr'
 description: 'Movie collection manager for Usenet and BitTorrent users'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/radarr'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/radarr'
 keywords:
   - 'film'
   - 'movies'
@@ -14,17 +14,17 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 6.2.1
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/Radarr/Radarr'
   - 'https://github.com/linuxserver/docker-radarr'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/radarr'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/radarr'

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -28,7 +28,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install radarr media-servarr/radarr
 ```

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'readarr'
 description: 'Ebook and audiobook collection manager for Usenet and BitTorrent users'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/readarr'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/readarr'
 keywords:
   - 'ebooks'
   - 'audiobooks'
@@ -14,7 +14,7 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.0
 appVersion: 0.4.19-nightly
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/readarr/icon.png'
 deprecated: true
 dependencies:
   - name: 'app-template'
@@ -22,10 +22,10 @@ dependencies:
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/Readarr/Readarr'
   - 'https://github.com/linuxserver/docker-readarr'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/readarr'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/readarr'

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -32,7 +32,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install readarr media-servarr/readarr
 ```

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'sabnzbd'
 description: 'SABnzbd is a program to download binary files from Usenet servers'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/sabnzbd'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/sabnzbd'
 keywords:
   - 'usenet'
   - 'newsreader'
@@ -10,17 +10,17 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 5.0.4
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/sabnzbd/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/sabnzbd/sabnzbd'
   - 'https://hub.docker.com/r/linuxserver/sabnzbd'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/sabnzbd'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/sabnzbd'

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -28,7 +28,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install sabnzbd media-servarr/sabnzbd
 ```

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: 'v2'
 name: 'sonarr'
 description: 'Television series manager for Usenet and BitTorrent users'
-home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/sonarr'
+home: 'https://github.com/Munsio/media-servarr/tree/main/charts/sonarr'
 keywords:
   - 'tv'
   - 'television'
@@ -15,17 +15,17 @@ kubeVersion: ">=1.28.0-0"
 type: 'application'
 version: 1.1.1
 appVersion: 4.0.17
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
+icon: 'https://github.com/Munsio/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'app-template'
     version: '5.0.1'
     repository: 'https://bjw-s-labs.github.io/helm-charts'
 maintainers:
   - name: 'media-servarr'
-    email: 'git@jo.shw.al'
-    url: 'https://github.com/drinkataco/media-servarr/'
+    email: 'git@treml.dev'
+    url: 'https://github.com/Munsio/media-servarr/'
 sources:
   - 'https://github.com/Sonarr/Sonarr'
   - 'https://github.com/linuxserver/docker-sonarr'
   - 'https://ghcr.io/onedr0p/exportarr'
-  - 'https://github.com/drinkataco/media-servarr/tree/main/charts/sonarr'
+  - 'https://github.com/Munsio/media-servarr/tree/main/charts/sonarr'

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -28,7 +28,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://munsio.github.io/media-servarr/
 
 helm install sonarr media-servarr/sonarr
 ```


### PR DESCRIPTION
## Summary
- Root `README.md`: badges now point at `Munsio/media-servarr` instead of `drinkataco/media-servarr`; the dead "Release" badge (no `release.yaml` workflow exists) is replaced with the actual `chart-page.yaml` publish workflow; `helm repo add` now uses this fork's real Pages URL instead of upstream's custom domain (and fixes a `mediar-servarr` typo).
- Every chart's `Chart.yaml` (`home`, `icon`, `sources`, `maintainers.url`) and README `helm repo add` line: same drinkataco/shw.al -> Munsio/munsio.github.io fix. `maintainers.email` no longer carries the original upstream author's personal address.
- `chart-page.yaml`: fixes the trigger branch from `base` (deleted when we migrated the default branch to `main`) to `main` -- chart publishing to GitHub Pages had silently stopped working.
- Left untouched: the `drinkataco/media-servarr#136` issue link in each chart README's changelog -- issues are disabled on this fork, so that citation can only ever resolve on upstream.

## Test plan
- [x] Validated all changed YAML files parse
- [ ] After merge, confirm the `Chart page` workflow run against `main` succeeds and `https://munsio.github.io/media-servarr/index.yaml` updates