### PR TITLE
Bump actions to Node 24 runtimes, switch linuxserver images off lscr.io

### DIFF
--- a/.github/workflows/chart-page.yaml
+++ b/.github/workflows/chart-page.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Configure Git

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
   lint-shell:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v7'
 
       - name: 'Run ShellCheck'
         uses: 'ludeeus/action-shellcheck@master'
@@ -15,10 +15,10 @@ jobs:
   lint-helm:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v7'
 
       - name: 'Set up Helm'
-        uses: 'azure/setup-helm@v3.5'
+        uses: 'azure/setup-helm@v5.0.1'
         with:
           version: 'v3.12.0'
 

--- a/charts/bazarr/values.yaml
+++ b/charts/bazarr/values.yaml
@@ -62,7 +62,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/bazarr
+            repository: ghcr.io/linuxserver/bazarr
             tag: "1.5.6"
           env:
             PGID: "1000"

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -51,7 +51,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/prowlarr
+            repository: ghcr.io/linuxserver/prowlarr
             tag: "2.4.0"
           env:
             PGID: "1000"

--- a/charts/radarr/values.yaml
+++ b/charts/radarr/values.yaml
@@ -50,7 +50,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/radarr
+            repository: ghcr.io/linuxserver/radarr
             tag: "6.2.1"
           env:
             PGID: "1000"

--- a/charts/readarr/values.yaml
+++ b/charts/readarr/values.yaml
@@ -51,7 +51,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/readarr
+            repository: ghcr.io/linuxserver/readarr
             tag: "0.4.19-nightly"
           env:
             PGID: "1000"

--- a/charts/sabnzbd/values.yaml
+++ b/charts/sabnzbd/values.yaml
@@ -76,7 +76,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/sabnzbd
+            repository: ghcr.io/linuxserver/sabnzbd
             tag: "5.0.4"
           env:
             PGID: "1000"

--- a/charts/sonarr/values.yaml
+++ b/charts/sonarr/values.yaml
@@ -51,7 +51,7 @@ app-template:
       containers:
         main:
           image:
-            repository: lscr.io/linuxserver/sonarr
+            repository: ghcr.io/linuxserver/sonarr
             tag: "4.0.17"
           env:
             PGID: "1000"


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` -> `v7`, `azure/setup-helm@v3.5` -> `v5.0.1` in both workflows. Fixes the "Node.js 20 is deprecated" warnings on every Lint and Chart page run -- checkout moved to Node 24 in v5.0.0, setup-helm in v5.0.0.
- Switch `bazarr`, `prowlarr`, `radarr`, `readarr`, `sabnzbd`, `sonarr` from `lscr.io/linuxserver/*` to `ghcr.io/linuxserver/*`. Dependabot was failing all 6 with `unknown_error` against `lscr.io`. Verified `lscr.io` is a GitHub-run proxy in front of `ghcr.io` (same `Www-Authenticate` realm, identical tag list from the same backend), so this is a same-image hostname swap, not a functional change -- and `ghcr.io` is a registry Dependabot handles fine.

## Test plan
- [x] Validated all changed YAML files parse
- [ ] Confirm the next Dependabot run updates cleanly against the 6 charts with no `unknown_error`
- [ ] Confirm CI runs show no more Node 20 deprecation warnings